### PR TITLE
reduced dldi size

### DIFF
--- a/source/dldi_header.s
+++ b/source/dldi_header.s
@@ -22,7 +22,7 @@
 	.word	0xBF8DA5ED		@ Magic number to identify this region
 	.asciz	" Chishm"		@ Identifying Magic string (8 bytes with null terminator)
 	.byte	0x01			@ Version number
-	.byte	0x0F	@32KiB	@ Log [base-2] of the maximum size of this driver in bytes.
+	.byte	0x0E	@16KiB	@ Log [base-2] of the maximum size of this driver in bytes.
 	.byte	FIX_GOT | FIX_BSS | FIX_GLUE	@ Sections to fix
 	.byte 	0x00			@ Space allocated in the application, not important here.
 	


### PR DESCRIPTION
new versions of libnds reduced max dldi size to 16 KiByte